### PR TITLE
Improve package docs and add return types

### DIFF
--- a/Commands/ExportConfigCommand.php
+++ b/Commands/ExportConfigCommand.php
@@ -1,16 +1,23 @@
 <?php
+declare(strict_types=1);
 
 namespace Famiq\ActiveDirectoryUser\Commands;
 
 use Illuminate\Console\Command;
 
+/**
+ * Comando para exportar el archivo de configuración LDAP del paquete.
+ */
 class ExportConfigCommand extends Command
 {
     protected $signature = 'FamiqADUser:export';
 
     protected $description = 'Export the FamiqADUser configuration file';
 
-    public function handle()
+    /**
+     * Ejecuta el proceso de exportación.
+     */
+    public function handle(): int
     {
         $source = __DIR__.'/../ldap.php';
         $destination = config_path('ldap.php');

--- a/Commands/GetUserInfoCommand.php
+++ b/Commands/GetUserInfoCommand.php
@@ -1,17 +1,24 @@
 <?php
+declare(strict_types=1);
 
 namespace Famiq\ActiveDirectoryUser\Commands;
 
 use Illuminate\Console\Command;
 use Famiq\ActiveDirectoryUser\ActiveDirectoryUser;
 
+/**
+ * Muestra información básica de un usuario de Active Directory.
+ */
 class GetUserInfoCommand extends Command
 {
     protected $signature = 'FamiqADUser:info {mail}';
 
     protected $description = 'Display information about an Active Directory user';
 
-    public function handle()
+    /**
+     * Ejecuta el comando de consulta.
+     */
+    public function handle(): int
     {
         $mail = $this->argument('mail');
         $user = ActiveDirectoryUser::findByMail($mail);

--- a/FamiqADUserServiceProvider.php
+++ b/FamiqADUserServiceProvider.php
@@ -1,17 +1,27 @@
 <?php
+declare(strict_types=1);
 
 namespace Famiq\ActiveDirectoryUser;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * Proveedor de servicios para integrar FamiqADUser en Laravel.
+ */
 class FamiqADUserServiceProvider extends ServiceProvider
 {
-    public function register()
+    /**
+     * Registra los servicios del paquete.
+     */
+    public function register(): void
     {
         //
     }
 
-    public function boot()
+    /**
+     * Inicializa el paquete cuando la aplicación se ejecuta en consola.
+     */
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/README.md
+++ b/README.md
@@ -1,14 +1,44 @@
 # FamiqADUser Vendor
 
-This package exposes the `ActiveDirectoryUser` class with LDAP configuration
-required for Active Directory integration. The class mirrors the application's
-original model and can be reused as an external dependency. The package also
-provides a command for exporting the configuration file.
+Integración con Active Directory pensada para aplicaciones Laravel. El paquete
+exponen la clase `ActiveDirectoryUser` con métodos utilitarios para consultar
+la estructura organizacional y comandos que facilitan la gestión de
+configuración.
 
-## New Features
+## Requisitos
 
-- `FamiqADUser:info {mail}` artisan command to quickly display information about a user.
-- Helper methods on `ActiveDirectoryUser`:
-  - `getPhoneNumber()` and `getMobileNumber()`.
-  - `getHierarchy()` to retrieve the manager chain.
-  - `findByDepartment()` and `searchBy()` static search helpers.
+- PHP 8.1 o superior.
+- Laravel 8 o posterior.
+
+## Instalación
+
+Instala el paquete mediante Composer:
+
+```bash
+composer require famiq/ad-user
+```
+
+Publica el archivo de configuración ejecutando:
+
+```bash
+php artisan FamiqADUser:export
+```
+
+Esto generará `config/ldap.php` con la configuración por defecto.
+
+## Uso
+
+El comando `FamiqADUser:info {mail}` permite consultar datos básicos de un
+usuario directamente desde la consola:
+
+```bash
+php artisan FamiqADUser:info usuario@dominio.com
+```
+
+La clase `ActiveDirectoryUser` incluye métodos como `getPhoneNumber()` o
+`getHierarchy()` para obtener información adicional del directorio.
+
+## Novedades
+
+- Métodos de búsqueda `findByDepartment()` y `searchBy()`.
+- Obtención de teléfonos y jerarquía de managers.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1",
         "directorytree/ldaprecord-laravel": "^3.4",
         "illuminate/support": "^8.0|^9.0|^10.0"
     }


### PR DESCRIPTION
## Summary
- require PHP 8.1 or newer
- document all classes and methods in Spanish
- add return type hints for better code quality
- update README with installation and usage instructions

## Testing
- `composer validate --no-interaction`
- `php -l ActiveDirectoryUser.php`
- `php -l FamiqADUserServiceProvider.php`
- `php -l Commands/ExportConfigCommand.php`
- `php -l Commands/GetUserInfoCommand.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d0a250b048322a292425aaecf4b77